### PR TITLE
Install APCu stable version

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,7 +24,7 @@ Installing PHP and required extensions
 
 Install APCu for fast access caching::
 
-   sudo pecl install apcu-beta
+   sudo pecl install apcu
 
 
 You'll most likely have to add the extension to your php.ini::


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.